### PR TITLE
Fix cancellation detection, duplicate prevention

### DIFF
--- a/city_scrapers/spiders/daltx_city_council.py
+++ b/city_scrapers/spiders/daltx_city_council.py
@@ -30,12 +30,12 @@ class DaltxCityCouncilSpider(LegistarSpider):
             event["Meeting Time"] = self._preprocess_meeting_time(event)
             meeting = Meeting(
                 title=event["Name"],
-                description=self._parse_description(event),
-                classification=self._parse_classification(event),
+                description="",
+                classification=CITY_COUNCIL,
                 start=self.legistar_start(event),
-                end=self._parse_end(event),
-                all_day=self._parse_all_day(event),
-                time_notes=self._parse_time_notes(event),
+                end=None,
+                all_day=False,
+                time_notes="",
                 location=self._parse_location(event),
                 links=self.legistar_links(event),
                 source=self.legistar_source(event),
@@ -47,26 +47,6 @@ class DaltxCityCouncilSpider(LegistarSpider):
             meeting["id"] = self._get_id(meeting)
 
             yield meeting
-
-    def _parse_description(self, item):
-        """Parse or generate meeting description."""
-        return ""
-
-    def _parse_classification(self, item):
-        """Parse or generate classification from allowed options."""
-        return CITY_COUNCIL
-
-    def _parse_end(self, item):
-        """Parse end datetime as a naive datetime object. Added by pipeline if None"""
-        return None
-
-    def _parse_time_notes(self, item):
-        """Parse any additional notes on the timing of the meeting"""
-        return ""
-
-    def _parse_all_day(self, item):
-        """Parse or generate all-day status. Defaults to False."""
-        return False
 
     def _parse_location(self, item):
         """Parse or generate location."""

--- a/city_scrapers/spiders/daltx_city_council.py
+++ b/city_scrapers/spiders/daltx_city_council.py
@@ -41,7 +41,13 @@ class DaltxCityCouncilSpider(LegistarSpider):
                 source=self.legistar_source(event),
             )
 
-            meeting["status"] = self._get_status(meeting)
+            location_raw = event.get("Meeting Location", "") or ""
+            location_text = (
+                location_raw.get("label", "")
+                if isinstance(location_raw, dict)
+                else location_raw
+            )
+            meeting["status"] = self._get_status(meeting, text=location_text)
             meeting["id"] = self._get_id(meeting)
 
             yield meeting
@@ -126,9 +132,18 @@ class DaltxCityCouncilSpider(LegistarSpider):
                     else:
                         data[header] = field_text
 
+                ical_url = (
+                    data["iCalendar"].get("url")
+                    if isinstance(data.get("iCalendar"), dict)
+                    else None
+                )
+                if ical_url is not None:
+                    if ical_url in self._scraped_urls:
+                        continue
+                    self._scraped_urls.add(ical_url)
                 if data:
                     events.append(dict(data))
             except Exception as e:
-                print(f"Error processing row: {str(e)}")
+                self.logger.warning(f"Error processing row: {str(e)}")
 
         return events

--- a/city_scrapers/spiders/daltx_city_council.py
+++ b/city_scrapers/spiders/daltx_city_council.py
@@ -41,13 +41,9 @@ class DaltxCityCouncilSpider(LegistarSpider):
                 source=self.legistar_source(event),
             )
 
-            location_raw = event.get("Meeting Location", "") or ""
-            location_text = (
-                location_raw.get("label", "")
-                if isinstance(location_raw, dict)
-                else location_raw
+            meeting["status"] = self._get_status(
+                meeting, text=meeting["location"]["name"] or ""
             )
-            meeting["status"] = self._get_status(meeting, text=location_text)
             meeting["id"] = self._get_id(meeting)
 
             yield meeting
@@ -144,6 +140,6 @@ class DaltxCityCouncilSpider(LegistarSpider):
                 if data:
                     events.append(dict(data))
             except Exception as e:
-                self.logger.warning(f"Error processing row: {str(e)}")
+                self.logger.warning(f"Error processing row: {e}", exc_info=True)
 
         return events

--- a/tests/test_daltx_city_council.py
+++ b/tests/test_daltx_city_council.py
@@ -92,3 +92,13 @@ def test_classification():
 def test_empty_meeting_time():
     """Test that empty meeting time is set to default time (0:00 AM)"""
     assert parsed_items[1]["start"] == datetime(2023, 2, 27, 0, 0)
+
+
+def test_cancelled_status():
+    """Meetings with CANCELLED in Meeting Location should have cancelled status"""
+    cancelled = next(
+        (m for m in parsed_items if "CANCELLED" in (m["location"]["name"] or "")),
+        None
+    )
+    assert cancelled is not None, "No cancelled meeting found in parsed_items"
+    assert cancelled["status"] == "cancelled"

--- a/tests/test_daltx_city_council.py
+++ b/tests/test_daltx_city_council.py
@@ -97,8 +97,7 @@ def test_empty_meeting_time():
 def test_cancelled_status():
     """Meetings with CANCELLED in Meeting Location should have cancelled status"""
     cancelled = next(
-        (m for m in parsed_items if "CANCELLED" in (m["location"]["name"] or "")),
-        None
+        (m for m in parsed_items if "CANCELLED" in (m["location"]["name"] or "")), None
     )
     assert cancelled is not None, "No cancelled meeting found in parsed_items"
     assert cancelled["status"] == "cancelled"


### PR DESCRIPTION
## Summary

**Issue:** #CS-51

Fix two bugs in the `daltx_city_council` spider causing bad data in Documenters:

1. **Cancellations not detected**: Dallas Legistar appends "CANCELLED" to the
   `Meeting Location` field rather than the title. The status check only looked
   at the title, so all cancelled meetings were published as `passed` or
   `tentative`. Fixed by passing the location text to `_get_status()`. Result:
   89 meetings now correctly surface as `cancelled`.

2. **Duplicate meetings**: The spider requests two year-pages (current year and
   previous year). A previous override of `_parse_legistar_events` accidentally
   removed the parent's iCalendar URL deduplication guard, causing the same
   meeting to be yielded once per year-page request — with potentially different
   IDs if `Meeting Time` was missing in one response. Restored the
   `_scraped_urls` check to prevent new duplicates from forming.

Also replaced a `print()` call with `self.logger.warning()` in the exception
handler.

## Checklist

- [x] Tests are implemented
- [x] All tests are passing
- [x] Style checks run
- [x] Style checks are passing
- [x] Code comments from template removed

## Questions

3 true duplicate meetings (no iCalendar URL, same title/time, different Legistar
entry IDs) remain in the output, they appear to be the same meeting scraped from
both year-page responses. A follow-on fix would be needed to deduplicate by
source URL or `(title, start_datetime)`. Is that in scope for this ticket or a
separate issue?