### PR TITLE
Add staging settings and workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,84 @@
+name: Staging
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+env:
+  CI: true
+  PYTHON_VERSION: 3.11
+  PIPENV_VENV_IN_PROJECT: true
+  CITY_SCRAPERS_ENV: staging
+  SCRAPY_SETTINGS_MODULE: city_scrapers.settings.staging
+  AUTOTHROTTLE_MAX_DELAY: 30.0
+  AUTOTHROTTLE_START_DELAY: 1.5
+  AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+  AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+  AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+  AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Run scrapers
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          ./.deploy.sh
+
+      - name: Combine output feeds
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/city_scrapers/settings/staging.py
+++ b/city_scrapers/settings/staging.py
@@ -1,0 +1,44 @@
+import os
+
+from .base import *  # noqa
+
+USER_AGENT = "City Scrapers [staging mode]. Learn more and say hello at https://city-scrapers.org"  # noqa
+
+ITEM_PIPELINES = {
+    "city_scrapers_core.pipelines.AzureDiffPipeline": 300,
+    "city_scrapers_core.pipelines.MeetingPipeline": 400,
+    "city_scrapers_core.pipelines.OpenCivicDataPipeline": 500,
+}
+
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+EXTENSIONS = {
+    "scrapy_sentry_errors.extensions.Errors": 10,
+    "scrapy.extensions.closespider.CloseSpider": None,
+}
+
+FEED_EXPORTERS = {
+    "json": "scrapy.exporters.JsonItemExporter",
+    "jsonlines": "scrapy.exporters.JsonLinesItemExporter",
+}
+
+FEED_FORMAT = "jsonlines"
+
+FEED_STORAGES = {
+    "azure": "city_scrapers_core.extensions.azure_storage.AzureBlobFeedStorage",
+}
+
+AZURE_ACCOUNT_NAME = os.getenv("AZURE_ACCOUNT_NAME")
+AZURE_ACCOUNT_KEY = os.getenv("AZURE_ACCOUNT_KEY")
+AZURE_CONTAINER = os.getenv("AZURE_STAGING_CONTAINER")
+
+FEED_URI = (
+    "azure://{account_name}:{account_key}@{container}"
+    "/%(year)s/%(month)s/%(day)s/%(hour_min)s/%(name)s.json"
+).format(
+    account_name=AZURE_ACCOUNT_NAME,
+    account_key=AZURE_ACCOUNT_KEY,
+    container=AZURE_CONTAINER,
+)
+
+FEED_PREFIX = "%Y/%m/%d"


### PR DESCRIPTION
## Summary
- Add `city_scrapers/settings/staging.py` for the staging workflow (writes to `AZURE_STAGING_CONTAINER`, uses staging User-Agent, no `AzureBlobStatusExtension`).
- Add `.github/workflows/staging.yml` — daily cron at `30 5 * * *` UTC, also triggers on push to `staging` branch, runs against the `staging` ref.

Mirrors the pattern established in [city-scrapers-charnc#11](https://github.com/City-Bureau/city-scrapers-charnc/pull/11), adapted for Dallas (Python 3.11, no Playwright).

## Notes
- Repo secret `AZURE_STAGING_CONTAINER` is already set to `meetings-feed-daltx-stg`.
- The `staging` branch has been created in the remote with this same commit so the workflow can check out `ref: staging`.

## Test plan
- [x] Workflow file YAML syntax is valid.
- [ ] First scheduled staging run (or manual `workflow_dispatch`) writes to the `meetings-feed-daltx-stg` Azure container without errors.