### PR TITLE
Pin scrapy to 2.11.2 and add python-dateutil

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-scrapy = "==2.11.1"
+scrapy = "==2.11.2"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-scrapy = "*"
+scrapy = "==2.11.1"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
+python-dateutil = "*"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e0614f73fe49d757b6764a3fe7f43602c64bdd0c6973df2f61fcc938e40c6f24"
+            "sha256": "fc59a87e4710b64b211cb2f60d4f480e03cf54c0e9674d1cabc9f08daa72db56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -736,12 +736,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:f1edee0cd214512054c01a8d031a8d213dddb53492b02c9e66256e3efe90d175",
-                "sha256:733a039c7423e52b69bf2810b5332093d4e42a848460359c07b02ecff8f73ebe"
+                "sha256:4be353d6abbb942a9f7e7614ca8b5f3d9037381176ac8d8859c8cac676e74fa0",
+                "sha256:dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "scrapy-sentry-errors": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa04638eafb76a8d0b85cd3100fb30c390d89a7c3bc97ec981f2b04f4dee70d0"
+            "sha256": "e0614f73fe49d757b6764a3fe7f43602c64bdd0c6973df2f61fcc938e40c6f24"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -582,6 +582,15 @@
             "markers": "python_version >= '3.7'",
             "version": "==25.0.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427",
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.9.0.post0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
@@ -727,12 +736,12 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:4be353d6abbb942a9f7e7614ca8b5f3d9037381176ac8d8859c8cac676e74fa0",
-                "sha256:dfbd565384fc3fffeba121f5a3a2d0899ac1f756d41432ca0879933fbfb3401d"
+                "sha256:f1edee0cd214512054c01a8d031a8d213dddb53492b02c9e66256e3efe90d175",
+                "sha256:733a039c7423e52b69bf2810b5332093d4e42a848460359c07b02ecff8f73ebe"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.2"
+            "version": "==2.11.1"
         },
         "scrapy-sentry-errors": {
             "hashes": [


### PR DESCRIPTION
## Summary
Two crawl-blockers on staging:

1. `ModuleNotFoundError: No module named 'dateutil'` — a recently merged spider imports `dateutil.parser` but the package wasn't in the Pipfile.
2. Newer scrapy (2.12+) passes `feed_options` as a kwarg to feed-storage classes, but `city-scrapers-core`'s `AzureBlobFeedStorage` doesn't accept it:
   ```
   TypeError: AzureBlobFeedStorage.__init__() got an unexpected keyword argument 'feed_options'
   ```

Pin to `scrapy = "==2.11.1"` (matching [city-scrapers-fortx](https://github.com/City-Bureau/city-scrapers-fortx/blob/master/Pipfile)) and add `python-dateutil`.

## Lock change is intentionally minimal
Only the new `python-dateutil` entry, the `scrapy` entry, and the Pipfile content hash. `six` (dateutil's only runtime dep) was already in the lock.

## Already applied to staging
Merged into the `staging` branch first (commit `768afea`) so the scheduled refresh-staging workflow stops failing. This PR brings the same fix to `main`.